### PR TITLE
Leverage performance

### DIFF
--- a/src/classes/action.ts
+++ b/src/classes/action.ts
@@ -400,7 +400,7 @@ export class KaminoAction {
     amount: string | BN,
     mint: PublicKey,
     owner: PublicKey,
-    obligationType: ObligationType,
+    obligation: KaminoObligation | ObligationType,
     extraComputeBudget: number = 1_000_000, // if > 0 then adds the ixn
     includeAtaIxns: boolean = true, // if true it includes create and close wsol and token atas,
     requestElevationGroup: boolean = false,
@@ -414,7 +414,7 @@ export class KaminoAction {
       mint,
       owner,
       kaminoMarket,
-      obligationType,
+      obligation,
       referrer,
       hostAta
     );

--- a/src/leverage/calcs.ts
+++ b/src/leverage/calcs.ts
@@ -28,6 +28,7 @@ export interface LeverageFormsCalcsArgs {
   flashBorrowReserveFlashLoanFeePercentage: Decimal;
   debtBorrowFactorPct: Decimal;
   priceCollToDebt: Decimal;
+  priceDebtToColl: Decimal;
 }
 
 export interface FormsCalcsResult {
@@ -54,10 +55,9 @@ export async function calculateMultiplyEffects(
     flashBorrowReserveFlashLoanFeePercentage,
     debtBorrowFactorPct,
     priceCollToDebt,
+    priceDebtToColl,
   }: LeverageFormsCalcsArgs
 ): Promise<FormsCalcsResult> {
-  const priceDebtToColl = new Decimal(1).div(priceCollToDebt);
-
   // calculate estimations for deposit operation
   const {
     adjustDepositPosition: depositModeEstimatedDepositAmount,

--- a/src/leverage/calcs.ts
+++ b/src/leverage/calcs.ts
@@ -27,6 +27,7 @@ export interface LeverageFormsCalcsArgs {
   activeTab: FormTabs;
   flashBorrowReserveFlashLoanFeePercentage: Decimal;
   debtBorrowFactorPct: Decimal;
+  priceCollToDebt: Decimal;
 }
 
 export interface FormsCalcsResult {
@@ -40,7 +41,6 @@ export interface FormsCalcsResult {
 
 export async function calculateMultiplyEffects(
   getPriceByTokenMintDecimal: (mint: PublicKey | string) => Decimal,
-  getJupiterPrice: (inputMint: PublicKey, outputMint: PublicKey) => Promise<Decimal>,
   {
     depositAmount,
     withdrawAmount,
@@ -53,10 +53,10 @@ export async function calculateMultiplyEffects(
     activeTab,
     flashBorrowReserveFlashLoanFeePercentage,
     debtBorrowFactorPct,
+    priceCollToDebt,
   }: LeverageFormsCalcsArgs
 ): Promise<FormsCalcsResult> {
-  const priceCollToDebt = await getJupiterPrice(collTokenMint, debtTokenMint);
-  const priceDebtToColl = await getJupiterPrice(debtTokenMint, collTokenMint);
+  const priceDebtToColl = new Decimal(1).div(priceCollToDebt);
 
   // calculate estimations for deposit operation
   const {
@@ -89,7 +89,7 @@ export async function calculateMultiplyEffects(
   const {
     adjustDepositPosition: adjustModeEstimatedDepositAmount,
     adjustBorrowPosition: adjustModeEstimateBorrowAmount,
-  } = await estimateAdjustMode(priceCollToDebt, {
+  } = estimateAdjustMode(priceCollToDebt, {
     targetLeverage,
     debtTokenMint,
     collTokenMint,
@@ -247,8 +247,9 @@ export function calcWithdrawAmounts(params: WithdrawParams): WithdrawResult {
 
   const initialDepositInCollateralToken = currentDepositPosition.minus(currentBorrowPosition.div(priceCollToDebt));
 
-  const amountToWithdrawDepositToken =
-    selectedTokenMint.toString() === collTokenMint.toString() ? withdrawAmount : withdrawAmount.div(priceCollToDebt);
+  const amountToWithdrawDepositToken = selectedTokenMint.equals(collTokenMint)
+    ? withdrawAmount
+    : withdrawAmount.div(priceCollToDebt);
 
   const targetDeposit = initialDepositInCollateralToken.minus(amountToWithdrawDepositToken).mul(targetLeverage);
 
@@ -373,7 +374,7 @@ export const estimateDepositMode = ({
   flashLoanFee,
   slippagePct = new Decimal(0),
 }: UseTransactionInfoStats) => {
-  const isDepositingCollToken = selectedTokenMint.toString() === collTokenMint.toString();
+  const isDepositingCollToken = selectedTokenMint.equals(collTokenMint);
 
   const finalCollTokenAmount = isDepositingCollToken
     ? new Decimal(amount).mul(targetLeverage).toNumber()

--- a/src/leverage/operations.ts
+++ b/src/leverage/operations.ts
@@ -237,6 +237,7 @@ export const getDepositWithLeverageIxns = async (props: {
   priceAinB: PriceAinBProvider;
   kamino: Kamino | undefined;
   obligationTypeTagOverride: ObligationTypeTag;
+  obligation: KaminoObligation | undefined;
 }): Promise<{ ixns: TransactionInstruction[]; lookupTablesAddresses: PublicKey[] }> => {
   const {
     connection,
@@ -255,6 +256,7 @@ export const getDepositWithLeverageIxns = async (props: {
     priceAinB,
     kamino,
     obligationTypeTagOverride = 1,
+    obligation,
   } = props;
   const collReserve = kaminoMarket.getReserveByMint(collTokenMint);
   const debtReserve = kaminoMarket.getReserveByMint(debtTokenMint);
@@ -334,8 +336,6 @@ export const getDepositWithLeverageIxns = async (props: {
     closeAtasIxns,
   } = await getAtasWithCreateIxnsIfMissing(connection, user, mintsToCreateAtas);
 
-  console.log('User Atas', toJson({ collTokenAta: collTokenAta.toString(), debtTokenAta: debtTokenAta.toString() }));
-
   // TODO: this needs to work the other way around also
   // TODO: marius test this with shorting leverage and with leverage looping
   const fillWsolAtaIxns: TransactionInstruction[] = [];
@@ -395,7 +395,7 @@ export const getDepositWithLeverageIxns = async (props: {
       .toString(),
     debtTokenMint,
     user,
-    obligationType,
+    obligation ? obligation : obligationType,
     0,
     false,
     true, // emode
@@ -412,6 +412,7 @@ export const getDepositWithLeverageIxns = async (props: {
   );
 
   let depositSwapper: SwapIxnsProvider;
+  let expectedDebtTokenAtaBalance: Decimal = new Decimal(0); // only needed for kTokens
 
   if (!collIsKtoken) {
     depositSwapper = swapper;
@@ -420,23 +421,24 @@ export const getDepositWithLeverageIxns = async (props: {
       throw Error('Ktoken use as collateral for leverage without Kamino instance');
     }
     depositSwapper = await getTokenToKtokenSwapper(connection, kaminoMarket, kamino, user, swapper, priceAinB, false);
-  }
 
-  let futureBalanceInAta = new Decimal(0);
-  if (debtTokenMint.equals(WRAPPED_SOL_MINT)) {
-    futureBalanceInAta = futureBalanceInAta.add(!collIsKtoken ? calcs.initDepositInSol : calcsKtoken.initDepositInSol);
+    let futureBalanceInAta = new Decimal(0);
+    if (debtTokenMint.equals(WRAPPED_SOL_MINT)) {
+      futureBalanceInAta = futureBalanceInAta.add(
+        !collIsKtoken ? calcs.initDepositInSol : calcsKtoken.initDepositInSol
+      );
+    }
+    futureBalanceInAta = futureBalanceInAta.add(
+      !collIsKtoken ? calcs.debtTokenToBorrow : calcsKtoken.flashBorrowInDebtToken
+    );
+    expectedDebtTokenAtaBalance = await getExpectedTokenBalanceAfterBorrow(
+      connection,
+      debtTokenMint,
+      user,
+      toLamports(futureBalanceInAta.toDecimalPlaces(debtReserve!.stats.decimals), debtReserve!.stats.decimals),
+      debtReserve!.state.liquidity.mintDecimals.toNumber()
+    );
   }
-  futureBalanceInAta = futureBalanceInAta.add(
-    !collIsKtoken ? calcs.debtTokenToBorrow : calcsKtoken.flashBorrowInDebtToken
-  );
-
-  const expectedDebtTokenAtaBalance = await getExpectedTokenBalanceAfterBorrow(
-    connection,
-    debtTokenMint,
-    user,
-    toLamports(futureBalanceInAta.toDecimalPlaces(debtReserve!.stats.decimals), debtReserve!.stats.decimals),
-    debtReserve!.state.liquidity.mintDecimals.toNumber()
-  );
 
   const [swapIxns, lookupTablesAddresses] = await depositSwapper(
     toLamports(!collIsKtoken ? calcs.swapDebtTokenIn : calcsKtoken.singleSidedDeposit, debtReserve!.stats.decimals)
@@ -449,7 +451,6 @@ export const getDepositWithLeverageIxns = async (props: {
   );
 
   if (collIsKtoken) {
-    const strategy = await kamino?.getStrategyByKTokenMint(collTokenMint);
     if (strategy?.strategy.strategyLookupTable) {
       lookupTablesAddresses.push(strategy?.strategy.strategyLookupTable!);
     } else {
@@ -516,6 +517,7 @@ export const getWithdrawWithLeverageIxns = async (props: {
   isKtoken: IsKtokenProvider;
   kamino: Kamino | undefined;
   obligationTypeTagOverride: ObligationTypeTag;
+  obligation: KaminoObligation | undefined;
 }): Promise<{ ixns: TransactionInstruction[]; lookupTablesAddresses: PublicKey[] }> => {
   const {
     connection,
@@ -535,6 +537,7 @@ export const getWithdrawWithLeverageIxns = async (props: {
     isKtoken,
     kamino,
     obligationTypeTagOverride,
+    obligation,
   } = props;
 
   const collReserve = kaminoMarket.getReserveByMint(collTokenMint);
@@ -577,9 +580,11 @@ export const getWithdrawWithLeverageIxns = async (props: {
 
   // Add slippage for the accrued interest rate amount
   const currentSlot = await kaminoMarket.getConnection().getSlot();
-  const obligation = await kaminoMarket.getObligationByAddress(obligationType.toPda(kaminoMarket.getAddress(), user));
-  const irSlippageBpsForDebt = obligation!
-    .estimateObligationInterestRate(debtReserve!, obligation?.state.borrows[0]!, currentSlot)
+  const userObligation = obligation
+    ? obligation
+    : await kaminoMarket.getObligationByAddress(obligationType.toPda(kaminoMarket.getAddress(), user));
+  const irSlippageBpsForDebt = userObligation!
+    .estimateObligationInterestRate(debtReserve!, userObligation?.state.borrows[0]!, currentSlot)
     .toDecimalPlaces(debtReserve?.state.liquidity.mintDecimals.toNumber()!, Decimal.ROUND_CEIL);
   // add 0.1 to irSlippageBpsForDebt because we don't want to estimate slightly less than SC and end up not reapying enough
   const repayAmount = initialRepayAmount
@@ -607,11 +612,12 @@ export const getWithdrawWithLeverageIxns = async (props: {
   const collTokenSwapIn = selectedTokenIsCollToken ? swapAmountIfWithdrawingColl : swapAmountIfWithdrawingDebt;
   const debtTokenExpectedSwapOut = collTokenSwapIn.mul(priceCollToDebt).div(new Decimal(1 + slippagePct / 100));
 
+  const strategy = collIsKtoken ? await kamino?.getStrategyByKTokenMint(collTokenMint) : undefined;
+
   console.log('Expecting to swap', collTokenSwapIn.toString(), 'coll for', debtTokenExpectedSwapOut.toString(), 'debt');
   // 1. Create atas & budget txns & user metadata
   let mintsToCreateAtas: PublicKey[] = [];
   if (collIsKtoken) {
-    const strategy = await kamino?.getStrategyByKTokenMint(collTokenMint);
     const secondTokenAta = strategy?.strategy.tokenAMint.equals(debtTokenMint)
       ? strategy?.strategy.tokenBMint!
       : strategy?.strategy.tokenAMint!;
@@ -690,7 +696,7 @@ export const getWithdrawWithLeverageIxns = async (props: {
     isClosingPosition ? U64_MAX : toLamports(depositTokenWithdrawAmount, collReserve!.stats.decimals).ceil().toString(),
     collTokenMint,
     user,
-    obligationType,
+    userObligation ? userObligation : obligationType,
     0,
     false,
     false,
@@ -700,7 +706,6 @@ export const getWithdrawWithLeverageIxns = async (props: {
   );
 
   if (collIsKtoken) {
-    const strategy = await kamino?.getStrategyByKTokenMint(collTokenMint);
     if (strategy?.strategy.strategyLookupTable) {
       lookupTablesAddresses.push(strategy?.strategy.strategyLookupTable!);
     } else {
@@ -750,6 +755,7 @@ export const getAdjustLeverageIxns = async (props: {
   priceAinB: PriceAinBProvider;
   kamino: Kamino | undefined;
   obligationTypeTagOverride: ObligationTypeTag;
+  obligation: KaminoObligation | undefined;
 }) => {
   const {
     connection,
@@ -769,6 +775,7 @@ export const getAdjustLeverageIxns = async (props: {
     priceAinB,
     kamino,
     obligationTypeTagOverride,
+    obligation,
   } = props;
 
   const collReserve = kaminoMarket.getReserveByMint(collTokenMint);
@@ -776,12 +783,14 @@ export const getAdjustLeverageIxns = async (props: {
 
   const deposited = fromLamports(depositedLamports, collReserve!.stats.decimals);
   const borrowed = fromLamports(borrowedLamports, debtReserve!.stats.decimals);
-  const obligation = (await kaminoMarket.getUserObligationsByTag(obligationTypeTagOverride, user)).filter(
-    (obligation: KaminoObligation) =>
-      obligation.getBorrowByMint(debtReserve!.getLiquidityMint()) !== undefined &&
-      obligation.getDepositByMint(collReserve!.getLiquidityMint()) !== undefined
-  )[0];
-  const currentLeverage = obligation!.refreshedStats.leverage;
+  const userObligation = obligation
+    ? obligation
+    : (await kaminoMarket.getUserObligationsByTag(obligationTypeTagOverride, user)).filter(
+        (obligation: KaminoObligation) =>
+          obligation.getBorrowByMint(debtReserve!.getLiquidityMint()) !== undefined &&
+          obligation.getDepositByMint(collReserve!.getLiquidityMint()) !== undefined
+      )[0];
+  const currentLeverage = userObligation!.refreshedStats.leverage;
   const isDepositViaLeverage = targetLeverage.gte(new Decimal(currentLeverage));
 
   let flashLoanFee = new Decimal(0);
@@ -825,7 +834,8 @@ export const getAdjustLeverageIxns = async (props: {
       isKtoken,
       priceAinB,
       kamino,
-      obligationTypeTagOverride
+      obligationTypeTagOverride,
+      userObligation
     );
     ixns = res.ixns;
     lookupTablesAddresses = res.lookupTablesAddresses;
@@ -844,7 +854,8 @@ export const getAdjustLeverageIxns = async (props: {
       referrer,
       isKtoken,
       kamino,
-      obligationTypeTagOverride
+      obligationTypeTagOverride,
+      userObligation
     );
     ixns = res.ixns;
     lookupTablesAddresses = res.lookupTablesAddresses;
@@ -874,7 +885,8 @@ export const getIncreaseLeverageIxns = async (
   isKtoken: IsKtokenProvider,
   priceAinB: PriceAinBProvider,
   kamino: Kamino | undefined,
-  obligationTypeTagOverride: ObligationTypeTag = 1
+  obligationTypeTagOverride: ObligationTypeTag = 1,
+  obligation: KaminoObligation | undefined
 ) => {
   const collReserve = kaminoMarket.getReserveByMint(collTokenMint);
   const debtReserve = kaminoMarket.getReserveByMint(debtTokenMint);
@@ -887,12 +899,12 @@ export const getIncreaseLeverageIxns = async (
   }
 
   // TODO: why are we recalculating here again
+  const strategy = collIsKtoken ? await kamino?.getStrategyByKTokenMint(collTokenMint) : undefined;
 
   // 1. Create atas & budget txns
   const budgetIxns = getComputeBudgetAndPriorityFeeIxns(3000000);
   let mintsToCreateAtas: PublicKey[] = [];
   if (collIsKtoken) {
-    const strategy = await kamino?.getStrategyByKTokenMint(collTokenMint);
     const secondTokenAta = strategy?.strategy.tokenAMint.equals(debtTokenMint)
       ? strategy?.strategy.tokenBMint!
       : strategy?.strategy.tokenAMint!;
@@ -948,7 +960,7 @@ export const getIncreaseLeverageIxns = async (
     toLamports(depositAmount, collReserve!.stats.decimals).floor().toString(),
     collTokenMint,
     user,
-    obligationType,
+    obligation ? obligation : obligationType,
     0,
     false,
     false,
@@ -970,7 +982,7 @@ export const getIncreaseLeverageIxns = async (
     toLamports(borrowAmount, debtReserve!.stats.decimals).ceil().toString(),
     debtTokenMint,
     user,
-    obligationType,
+    obligation ? obligation : obligationType,
     0,
     false,
     false,
@@ -980,23 +992,24 @@ export const getIncreaseLeverageIxns = async (
   );
 
   let depositSwapper: SwapIxnsProvider;
+  let expectedDebtTokenAtaBalance = new Decimal(0);
 
   if (collIsKtoken) {
     if (kamino === undefined) {
       throw Error('Ktoken use as collateral for leverage without Kamino instance');
     }
     depositSwapper = await getTokenToKtokenSwapper(connection, kaminoMarket, kamino, user, swapper, priceAinB, false);
+
+    expectedDebtTokenAtaBalance = await getExpectedTokenBalanceAfterBorrow(
+      connection,
+      debtTokenMint,
+      user,
+      toLamports(!collIsKtoken ? borrowAmount : amountToFashBorrowDebt, debtReserve!.stats.decimals).floor(),
+      debtReserve!.state.liquidity.mintDecimals.toNumber()
+    );
   } else {
     depositSwapper = swapper;
   }
-
-  const expectedDebtTokenAtaBalance = await getExpectedTokenBalanceAfterBorrow(
-    connection,
-    debtTokenMint,
-    user,
-    toLamports(!collIsKtoken ? borrowAmount : amountToFashBorrowDebt, debtReserve!.stats.decimals).floor(),
-    debtReserve!.state.liquidity.mintDecimals.toNumber()
-  );
 
   const [swapIxns, lookupTablesAddresses] = await depositSwapper(
     toLamports(!collIsKtoken ? borrowAmount : amountToFashBorrowDebt, debtReserve!.stats.decimals)
@@ -1046,7 +1059,6 @@ export const getIncreaseLeverageIxns = async (
 
   // Create and send transaction
   if (collIsKtoken) {
-    const strategy = await kamino?.getStrategyByKTokenMint(collTokenMint);
     if (strategy?.strategy.strategyLookupTable) {
       lookupTablesAddresses.push(strategy?.strategy.strategyLookupTable!);
     } else {
@@ -1075,7 +1087,8 @@ export const getDecreaseLeverageIxns = async (
   referrer: PublicKey,
   isKtoken: IsKtokenProvider,
   kamino: Kamino | undefined,
-  obligationTypeTagOverride: ObligationTypeTag = 1
+  obligationTypeTagOverride: ObligationTypeTag = 1,
+  obligation
 ) => {
   console.log(
     'getDecreaseLeverageIxns',
@@ -1087,11 +1100,12 @@ export const getDecreaseLeverageIxns = async (
 
   const flashLoanFee = debtReserve?.getFlashLoanFee() || new Decimal(0);
 
+  const strategy = collIsKtoken ? await kamino?.getStrategyByKTokenMint(collTokenMint) : undefined;
+
   // 1. Create atas & budget txns
   const budgetIxns = getComputeBudgetAndPriorityFeeIxns(3000000);
   let mintsToCreateAtas: PublicKey[] = [];
   if (collIsKtoken) {
-    const strategy = await kamino?.getStrategyByKTokenMint(collTokenMint);
     const secondTokenAta = strategy?.strategy.tokenAMint.equals(debtTokenMint)
       ? strategy?.strategy.tokenBMint!
       : strategy?.strategy.tokenAMint!;
@@ -1153,7 +1167,7 @@ export const getDecreaseLeverageIxns = async (
     toLamports(repayAmount, debtReserve!.stats.decimals).floor().toString(),
     debtTokenMint,
     user,
-    obligationType,
+    obligation ? obligation : obligationType,
     undefined,
     0,
     false,
@@ -1173,7 +1187,7 @@ export const getDecreaseLeverageIxns = async (
     toLamports(withdrawAmountWithSlippageAndFlashLoanFee, collReserve!.stats.decimals).ceil().toString(),
     collTokenMint,
     user,
-    obligationType,
+    obligation ? obligation : obligationType,
     0,
     false,
     false,
@@ -1223,7 +1237,6 @@ export const getDecreaseLeverageIxns = async (
   });
 
   if (collIsKtoken) {
-    const strategy = await kamino?.getStrategyByKTokenMint(collTokenMint);
     if (strategy?.strategy.strategyLookupTable) {
       lookupTablesAddresses.push(strategy?.strategy.strategyLookupTable!);
     } else {

--- a/src/leverage/operations.ts
+++ b/src/leverage/operations.ts
@@ -1,16 +1,7 @@
 import { Connection, LAMPORTS_PER_SOL, PublicKey, TransactionInstruction } from '@solana/web3.js';
 import Decimal from 'decimal.js';
-import { KaminoAction, KaminoMarket, KaminoObligation } from '../classes';
+import { KaminoAction, KaminoMarket, KaminoObligation, lamportsToNumberDecimal as fromLamports } from '../classes';
 import { getFlashLoanInstructions } from './instructions';
-
-import {
-  lamportsToNumberDecimal as fromLamports,
-  getExpectedTokenBalanceAfterBorrow,
-  getKtokenToTokenSwapper,
-  getTokenToKtokenSwapper,
-  WRAPPED_SOL_MINT,
-  simulateMintKToken,
-} from '../lib';
 
 import { numberToLamportsDecimal as toLamports } from '../classes';
 import {
@@ -19,15 +10,17 @@ import {
   ObligationType,
   ObligationTypeTag,
   U64_MAX,
+  WRAPPED_SOL_MINT,
   getAssociatedTokenAddress,
   getAtasWithCreateIxnsIfMissing,
   getComputeBudgetAndPriorityFeeIxns,
   getDepositWsolIxns,
   removeBudgetAndAtaIxns,
 } from '../utils';
-import { calcAdjustAmounts, calcWithdrawAmounts, toJson } from './calcs';
+import { calcAdjustAmounts, calcWithdrawAmounts, simulateMintKToken, toJson } from './calcs';
 import { TOKEN_PROGRAM_ID, Token } from '@solana/spl-token';
 import { Kamino, InstructionsWithLookupTables, StrategyWithAddress, TokenAmounts } from '@hubbleprotocol/kamino-sdk';
+import { getExpectedTokenBalanceAfterBorrow, getKtokenToTokenSwapper, getTokenToKtokenSwapper } from './utils';
 
 export type SwapIxnsProvider = (
   amountInLamports: number,
@@ -237,7 +230,7 @@ export const getDepositWithLeverageIxns = async (props: {
   priceAinB: PriceAinBProvider;
   kamino: Kamino | undefined;
   obligationTypeTagOverride: ObligationTypeTag;
-  obligation: KaminoObligation | undefined;
+  obligation: KaminoObligation | null;
 }): Promise<{ ixns: TransactionInstruction[]; lookupTablesAddresses: PublicKey[] }> => {
   const {
     connection,
@@ -517,7 +510,7 @@ export const getWithdrawWithLeverageIxns = async (props: {
   isKtoken: IsKtokenProvider;
   kamino: Kamino | undefined;
   obligationTypeTagOverride: ObligationTypeTag;
-  obligation: KaminoObligation | undefined;
+  obligation: KaminoObligation | null;
 }): Promise<{ ixns: TransactionInstruction[]; lookupTablesAddresses: PublicKey[] }> => {
   const {
     connection,
@@ -755,7 +748,7 @@ export const getAdjustLeverageIxns = async (props: {
   priceAinB: PriceAinBProvider;
   kamino: Kamino | undefined;
   obligationTypeTagOverride: ObligationTypeTag;
-  obligation: KaminoObligation | undefined;
+  obligation: KaminoObligation | null;
 }) => {
   const {
     connection,
@@ -886,7 +879,7 @@ export const getIncreaseLeverageIxns = async (
   priceAinB: PriceAinBProvider,
   kamino: Kamino | undefined,
   obligationTypeTagOverride: ObligationTypeTag = 1,
-  obligation: KaminoObligation | undefined
+  obligation: KaminoObligation | null
 ) => {
   const collReserve = kaminoMarket.getReserveByMint(collTokenMint);
   const debtReserve = kaminoMarket.getReserveByMint(debtTokenMint);

--- a/src/leverage/utils.ts
+++ b/src/leverage/utils.ts
@@ -5,7 +5,6 @@ import { PriceAinBProvider, SwapIxnsProvider } from './operations';
 import Decimal from 'decimal.js';
 import { getTokenAccountBalanceDecimal } from '../utils';
 import { numberToLamportsDecimal } from '../classes/utils';
-import { toJson } from './calcs';
 import BN from 'bn.js';
 
 export interface KaminoSwapperIxBuilder {
@@ -140,7 +139,7 @@ export const getKtokenToTokenSwapper = async (
       amountToWithdraw
     );
 
-    if (amountOutMint.toString() === kaminoStrategy?.strategy.tokenAMint.toString()) {
+    if (amountOutMint.equals(kaminoStrategy?.strategy.tokenAMint!)) {
       const [swapIxs, swapLookupTables] = await swapper(
         estimatedBOut.toNumber(),
         kaminoStrategy?.strategy.tokenBMint!,
@@ -149,7 +148,7 @@ export const getKtokenToTokenSwapper = async (
       );
 
       return [[...ixWithdraw.prerequisiteIxs, ixWithdraw.withdrawIx, ...swapIxs], swapLookupTables];
-    } else if (amountOutMint.toString() === kaminoStrategy?.strategy.tokenBMint.toString()) {
+    } else if (amountOutMint.equals(kaminoStrategy?.strategy.tokenBMint!)) {
       const [swapIxs, swapLookupTables] = await swapper(
         estimatedAOut.toNumber(),
         kaminoStrategy?.strategy.tokenAMint!,
@@ -189,8 +188,6 @@ export async function getKtokenWithdrawEstimatesAndPrice(
     .toDecimalPlaces(18);
 
   const withdrawFee = new Decimal(10_000).sub(new Decimal(kaminoStrategy.strategy.withdrawFee.toString()));
-
-  console.log('sharesData', toJson(sharesData));
 
   // TODO: Mihai/Marius improve - currently subtracting due to decimal accuracy issues compared to yvaults SC
   // for both A and B op: .sub(0.000002)

--- a/src/utils/ata.ts
+++ b/src/utils/ata.ts
@@ -151,11 +151,11 @@ export function removeBudgetAndAtaIxns(ixns: TransactionInstruction[], mints: st
   return ixns.filter((ixn) => {
     const { programId, keys } = ixn;
 
-    if (programId.toString() === ComputeBudgetProgram.programId.toString()) {
+    if (programId.equals(ComputeBudgetProgram.programId)) {
       return false;
     }
 
-    if (programId.toString() === ASSOCIATED_TOKEN_PROGRAM_ID.toString()) {
+    if (programId.equals(ASSOCIATED_TOKEN_PROGRAM_ID)) {
       const mint = keys[3];
 
       return !mints.includes(mint.pubkey.toString());

--- a/tests/leverage_calcs.test.ts
+++ b/tests/leverage_calcs.test.ts
@@ -42,6 +42,7 @@ describe('Leverage calculation tests', function () {
     const [depositAmount, withdrawAmount] = [new Decimal(1.0), new Decimal(0)];
     const targetLeverage = new Decimal(3);
     const priceCollToDebt = getJupiterPrice(collTokenMint, debtTokenMint);
+    const priceDebtToColl = getJupiterPrice(debtTokenMint, collTokenMint);
 
     const res = await calculateMultiplyEffects(getPriceByTokenMintDecimal, {
       depositAmount,
@@ -56,6 +57,7 @@ describe('Leverage calculation tests', function () {
       flashBorrowReserveFlashLoanFeePercentage: new Decimal(0.0),
       debtBorrowFactorPct: new Decimal(100),
       priceCollToDebt,
+      priceDebtToColl,
     });
 
     console.log('calculateMultiplyEffects: ', toJson(res));
@@ -228,6 +230,7 @@ describe('Leverage calculation tests', function () {
     const [depositAmount, withdrawAmount] = [new Decimal('0.8333333333333334'), new Decimal(0)];
     const targetLeverage = new Decimal(3);
     const priceCollToDebt = getJupiterPrice(collTokenMint, debtTokenMint);
+    const priceDebtToColl = getJupiterPrice(debtTokenMint, collTokenMint);
 
     const res = await calculateMultiplyEffects(getPriceByTokenMintDecimal, {
       depositAmount,
@@ -242,6 +245,7 @@ describe('Leverage calculation tests', function () {
       flashBorrowReserveFlashLoanFeePercentage: new Decimal(0.0),
       debtBorrowFactorPct: new Decimal(100),
       priceCollToDebt,
+      priceDebtToColl,
     });
 
     console.log('calculateMultiplyEffects: ', toJson(res));
@@ -268,6 +272,7 @@ describe('Leverage calculation tests', function () {
     const [depositAmount, withdrawAmount] = [new Decimal('1.0'), new Decimal('0')];
     const targetLeverage = new Decimal('3');
     const priceCollToDebt = getJupiterPrice(collTokenMint, debtTokenMint);
+    const priceDebtToColl = getJupiterPrice(debtTokenMint, collTokenMint);
 
     const res = await calculateMultiplyEffects(getPriceByTokenMintDecimal, {
       depositAmount,
@@ -282,6 +287,7 @@ describe('Leverage calculation tests', function () {
       flashBorrowReserveFlashLoanFeePercentage: new Decimal(0.0),
       debtBorrowFactorPct: new Decimal(100),
       priceCollToDebt,
+      priceDebtToColl,
     });
 
     console.log('calculateMultiplyEffects: ', toJson(res));
@@ -308,6 +314,7 @@ describe('Leverage calculation tests', function () {
     const [depositAmount, withdrawAmount] = [new Decimal('0.8333333333333334'), new Decimal(0)];
     const targetLeverage = new Decimal('3');
     const priceCollToDebt = getJupiterPrice(collTokenMint, debtTokenMint);
+    const priceDebtToColl = getJupiterPrice(debtTokenMint, collTokenMint);
 
     const res = await calculateMultiplyEffects(getPriceByTokenMintDecimal, {
       depositAmount,
@@ -322,6 +329,7 @@ describe('Leverage calculation tests', function () {
       flashBorrowReserveFlashLoanFeePercentage: new Decimal(0.0),
       debtBorrowFactorPct: new Decimal(100),
       priceCollToDebt,
+      priceDebtToColl,
     });
 
     console.log('calculateMultiplyEffects: ', toJson(res));
@@ -350,6 +358,7 @@ describe('Leverage calculation tests', function () {
     const [depositAmount, withdrawAmount] = [new Decimal('0'), new Decimal('1')];
     const targetLeverage = new Decimal('5');
     const priceCollToDebt = getJupiterPrice(collTokenMint, debtTokenMint);
+    const priceDebtToColl = getJupiterPrice(debtTokenMint, collTokenMint);
 
     const res = await calculateMultiplyEffects(getPriceByTokenMintDecimal, {
       depositAmount,
@@ -364,6 +373,7 @@ describe('Leverage calculation tests', function () {
       flashBorrowReserveFlashLoanFeePercentage: new Decimal(0.0),
       debtBorrowFactorPct: new Decimal(100),
       priceCollToDebt,
+      priceDebtToColl,
     });
 
     console.log('calculateMultiplyEffects: ', toJson(res));
@@ -392,6 +402,7 @@ describe('Leverage calculation tests', function () {
     const [depositAmount, withdrawAmount] = [new Decimal('0'), new Decimal('0.8333333333333334')];
     const targetLeverage = new Decimal('5');
     const priceCollToDebt = getJupiterPrice(collTokenMint, debtTokenMint);
+    const priceDebtToColl = getJupiterPrice(debtTokenMint, collTokenMint);
 
     const res = await calculateMultiplyEffects(getPriceByTokenMintDecimal, {
       depositAmount,
@@ -406,6 +417,7 @@ describe('Leverage calculation tests', function () {
       flashBorrowReserveFlashLoanFeePercentage: new Decimal(0.0),
       debtBorrowFactorPct: new Decimal(100),
       priceCollToDebt,
+      priceDebtToColl,
     });
 
     console.log('calculateMultiplyEffects: ', toJson(res));
@@ -435,6 +447,7 @@ describe('Leverage calculation tests', function () {
     const [depositAmount, withdrawAmount] = [new Decimal('0'), new Decimal('0.0')];
     const targetLeverage = new Decimal('3');
     const priceCollToDebt = getJupiterPrice(collTokenMint, debtTokenMint);
+    const priceDebtToColl = getJupiterPrice(debtTokenMint, collTokenMint);
 
     const res = await calculateMultiplyEffects(getPriceByTokenMintDecimal, {
       depositAmount,
@@ -449,6 +462,7 @@ describe('Leverage calculation tests', function () {
       flashBorrowReserveFlashLoanFeePercentage: new Decimal(0.0),
       debtBorrowFactorPct: new Decimal(100),
       priceCollToDebt,
+      priceDebtToColl,
     });
 
     console.log('calculateMultiplyEffects: ', toJson(res));
@@ -465,6 +479,7 @@ describe('Leverage calculation tests', function () {
     const [depositAmount, withdrawAmount] = [new Decimal('0'), new Decimal('0.0')];
     const targetLeverage = new Decimal('3');
     const priceCollToDebt = getJupiterPrice(collTokenMint, debtTokenMint);
+    const priceDebtToColl = getJupiterPrice(debtTokenMint, collTokenMint);
 
     const res = await calculateMultiplyEffects(getPriceByTokenMintDecimal, {
       depositAmount,
@@ -479,6 +494,7 @@ describe('Leverage calculation tests', function () {
       flashBorrowReserveFlashLoanFeePercentage: new Decimal(0.0),
       debtBorrowFactorPct: new Decimal(100),
       priceCollToDebt,
+      priceDebtToColl,
     });
 
     console.log('calculateMultiplyEffects: ', toJson(res));
@@ -530,6 +546,7 @@ describe('Leverage calculation tests', function () {
     const [depositAmount, withdrawAmount] = [new Decimal('0'), new Decimal('0.0')];
     const targetLeverage = new Decimal('2');
     const priceCollToDebt = getJupiterPrice(collTokenMint, debtTokenMint, getPriceToUsd);
+    const priceDebtToColl = getJupiterPrice(debtTokenMint, collTokenMint);
 
     const res = await calculateMultiplyEffects(getPriceToUsd, {
       depositAmount,
@@ -544,6 +561,7 @@ describe('Leverage calculation tests', function () {
       flashBorrowReserveFlashLoanFeePercentage: new Decimal(0.0),
       debtBorrowFactorPct: new Decimal(100),
       priceCollToDebt,
+      priceDebtToColl,
     });
 
     console.log('calculateMultiplyEffects: ', toJson(res));

--- a/tests/leverage_calcs.test.ts
+++ b/tests/leverage_calcs.test.ts
@@ -41,8 +41,9 @@ describe('Leverage calculation tests', function () {
     const [deposited, borrowed] = [new Decimal(0), new Decimal(0)];
     const [depositAmount, withdrawAmount] = [new Decimal(1.0), new Decimal(0)];
     const targetLeverage = new Decimal(3);
+    const priceCollToDebt = getJupiterPrice(collTokenMint, debtTokenMint);
 
-    const res = await calculateMultiplyEffects(getPriceByTokenMintDecimal, async (x, y) => getJupiterPrice(x, y), {
+    const res = await calculateMultiplyEffects(getPriceByTokenMintDecimal, {
       depositAmount,
       withdrawAmount,
       deposited,
@@ -54,6 +55,7 @@ describe('Leverage calculation tests', function () {
       activeTab: FormTabs.deposit,
       flashBorrowReserveFlashLoanFeePercentage: new Decimal(0.0),
       debtBorrowFactorPct: new Decimal(100),
+      priceCollToDebt,
     });
 
     console.log('calculateMultiplyEffects: ', toJson(res));
@@ -225,8 +227,9 @@ describe('Leverage calculation tests', function () {
     const [deposited, borrowed] = [new Decimal(0), new Decimal(0)];
     const [depositAmount, withdrawAmount] = [new Decimal('0.8333333333333334'), new Decimal(0)];
     const targetLeverage = new Decimal(3);
+    const priceCollToDebt = getJupiterPrice(collTokenMint, debtTokenMint);
 
-    const res = await calculateMultiplyEffects(getPriceByTokenMintDecimal, async (x, y) => getJupiterPrice(x, y), {
+    const res = await calculateMultiplyEffects(getPriceByTokenMintDecimal, {
       depositAmount,
       withdrawAmount,
       deposited,
@@ -238,6 +241,7 @@ describe('Leverage calculation tests', function () {
       activeTab: FormTabs.deposit,
       flashBorrowReserveFlashLoanFeePercentage: new Decimal(0.0),
       debtBorrowFactorPct: new Decimal(100),
+      priceCollToDebt,
     });
 
     console.log('calculateMultiplyEffects: ', toJson(res));
@@ -263,8 +267,9 @@ describe('Leverage calculation tests', function () {
     const [deposited, borrowed] = [new Decimal('25.0'), new Decimal('20.0')];
     const [depositAmount, withdrawAmount] = [new Decimal('1.0'), new Decimal('0')];
     const targetLeverage = new Decimal('3');
+    const priceCollToDebt = getJupiterPrice(collTokenMint, debtTokenMint);
 
-    const res = await calculateMultiplyEffects(getPriceByTokenMintDecimal, async (x, y) => getJupiterPrice(x, y), {
+    const res = await calculateMultiplyEffects(getPriceByTokenMintDecimal, {
       depositAmount,
       withdrawAmount,
       deposited,
@@ -276,6 +281,7 @@ describe('Leverage calculation tests', function () {
       activeTab: FormTabs.deposit,
       flashBorrowReserveFlashLoanFeePercentage: new Decimal(0.0),
       debtBorrowFactorPct: new Decimal(100),
+      priceCollToDebt,
     });
 
     console.log('calculateMultiplyEffects: ', toJson(res));
@@ -301,8 +307,9 @@ describe('Leverage calculation tests', function () {
     const [deposited, borrowed] = [new Decimal('25.0'), new Decimal('20.0')];
     const [depositAmount, withdrawAmount] = [new Decimal('0.8333333333333334'), new Decimal(0)];
     const targetLeverage = new Decimal('3');
+    const priceCollToDebt = getJupiterPrice(collTokenMint, debtTokenMint);
 
-    const res = await calculateMultiplyEffects(getPriceByTokenMintDecimal, async (x, y) => getJupiterPrice(x, y), {
+    const res = await calculateMultiplyEffects(getPriceByTokenMintDecimal, {
       depositAmount,
       withdrawAmount,
       deposited,
@@ -314,6 +321,7 @@ describe('Leverage calculation tests', function () {
       activeTab: FormTabs.deposit,
       flashBorrowReserveFlashLoanFeePercentage: new Decimal(0.0),
       debtBorrowFactorPct: new Decimal(100),
+      priceCollToDebt,
     });
 
     console.log('calculateMultiplyEffects: ', toJson(res));
@@ -341,8 +349,9 @@ describe('Leverage calculation tests', function () {
     const [deposited, borrowed] = [new Decimal('41.66666666666667'), new Decimal('40')];
     const [depositAmount, withdrawAmount] = [new Decimal('0'), new Decimal('1')];
     const targetLeverage = new Decimal('5');
+    const priceCollToDebt = getJupiterPrice(collTokenMint, debtTokenMint);
 
-    const res = await calculateMultiplyEffects(getPriceByTokenMintDecimal, async (x, y) => getJupiterPrice(x, y), {
+    const res = await calculateMultiplyEffects(getPriceByTokenMintDecimal, {
       depositAmount,
       withdrawAmount,
       deposited,
@@ -354,6 +363,7 @@ describe('Leverage calculation tests', function () {
       activeTab: FormTabs.withdraw,
       flashBorrowReserveFlashLoanFeePercentage: new Decimal(0.0),
       debtBorrowFactorPct: new Decimal(100),
+      priceCollToDebt,
     });
 
     console.log('calculateMultiplyEffects: ', toJson(res));
@@ -381,8 +391,9 @@ describe('Leverage calculation tests', function () {
     const [deposited, borrowed] = [new Decimal('41.66666666666667'), new Decimal('40')];
     const [depositAmount, withdrawAmount] = [new Decimal('0'), new Decimal('0.8333333333333334')];
     const targetLeverage = new Decimal('5');
+    const priceCollToDebt = getJupiterPrice(collTokenMint, debtTokenMint);
 
-    const res = await calculateMultiplyEffects(getPriceByTokenMintDecimal, async (x, y) => getJupiterPrice(x, y), {
+    const res = await calculateMultiplyEffects(getPriceByTokenMintDecimal, {
       depositAmount,
       withdrawAmount,
       deposited,
@@ -394,6 +405,7 @@ describe('Leverage calculation tests', function () {
       activeTab: FormTabs.withdraw,
       flashBorrowReserveFlashLoanFeePercentage: new Decimal(0.0),
       debtBorrowFactorPct: new Decimal(100),
+      priceCollToDebt,
     });
 
     console.log('calculateMultiplyEffects: ', toJson(res));
@@ -422,8 +434,9 @@ describe('Leverage calculation tests', function () {
     const [deposited, borrowed] = [new Decimal('41.66666666666667'), new Decimal('40')];
     const [depositAmount, withdrawAmount] = [new Decimal('0'), new Decimal('0.0')];
     const targetLeverage = new Decimal('3');
+    const priceCollToDebt = getJupiterPrice(collTokenMint, debtTokenMint);
 
-    const res = await calculateMultiplyEffects(getPriceByTokenMintDecimal, async (x, y) => getJupiterPrice(x, y), {
+    const res = await calculateMultiplyEffects(getPriceByTokenMintDecimal, {
       depositAmount,
       withdrawAmount,
       deposited,
@@ -435,6 +448,7 @@ describe('Leverage calculation tests', function () {
       activeTab: FormTabs.adjust,
       flashBorrowReserveFlashLoanFeePercentage: new Decimal(0.0),
       debtBorrowFactorPct: new Decimal(100),
+      priceCollToDebt,
     });
 
     console.log('calculateMultiplyEffects: ', toJson(res));
@@ -450,8 +464,9 @@ describe('Leverage calculation tests', function () {
     const [deposited, borrowed] = [new Decimal('0.00005008'), new Decimal('0.02')];
     const [depositAmount, withdrawAmount] = [new Decimal('0'), new Decimal('0.0')];
     const targetLeverage = new Decimal('3');
+    const priceCollToDebt = getJupiterPrice(collTokenMint, debtTokenMint);
 
-    const res = await calculateMultiplyEffects(getPriceByTokenMintDecimal, async (x, y) => getJupiterPrice(x, y), {
+    const res = await calculateMultiplyEffects(getPriceByTokenMintDecimal, {
       depositAmount,
       withdrawAmount,
       deposited,
@@ -463,6 +478,7 @@ describe('Leverage calculation tests', function () {
       activeTab: FormTabs.withdraw,
       flashBorrowReserveFlashLoanFeePercentage: new Decimal(0.0),
       debtBorrowFactorPct: new Decimal(100),
+      priceCollToDebt,
     });
 
     console.log('calculateMultiplyEffects: ', toJson(res));
@@ -513,8 +529,9 @@ describe('Leverage calculation tests', function () {
     const [deposited, borrowed] = [new Decimal('10.68'), new Decimal('8.12')];
     const [depositAmount, withdrawAmount] = [new Decimal('0'), new Decimal('0.0')];
     const targetLeverage = new Decimal('2');
+    const priceCollToDebt = getJupiterPrice(collTokenMint, debtTokenMint, getPriceToUsd);
 
-    const res = await calculateMultiplyEffects(getPriceToUsd, async (x, y) => getJupiterPrice(x, y, getPriceToUsd), {
+    const res = await calculateMultiplyEffects(getPriceToUsd, {
       depositAmount,
       withdrawAmount,
       deposited,
@@ -526,6 +543,7 @@ describe('Leverage calculation tests', function () {
       activeTab: FormTabs.adjust,
       flashBorrowReserveFlashLoanFeePercentage: new Decimal(0.0),
       debtBorrowFactorPct: new Decimal(100),
+      priceCollToDebt,
     });
 
     console.log('calculateMultiplyEffects: ', toJson(res));

--- a/tests/leverage_ktokens_swapper.test.ts
+++ b/tests/leverage_ktokens_swapper.test.ts
@@ -1,14 +1,4 @@
 import { Keypair, PublicKey } from '@solana/web3.js';
-import {
-  buildVersionedTransaction,
-  getAssociatedTokenAddress,
-  getExpectedTokenBalanceAfterBorrow,
-  getKtokenToTokenSwapper,
-  getTokenAccountBalance,
-  getTokenToKtokenSwapper,
-  sendAndConfirmVersionedTransaction,
-  sleep,
-} from '../src';
 import { WSOL_MINT, getLocalSwapper, getPriceAinB } from './leverage_utils';
 import { setupStrategyAndMarketWithInitialLiquidity, newUser, createLookupTable } from './setup_utils';
 import Decimal from 'decimal.js';
@@ -17,6 +7,14 @@ import { TOKEN_PROGRAM_ID, Token } from '@solana/spl-token';
 import { Price } from './kamino/price';
 import { assertFuzzyEq } from './assert';
 import { reloadReservesAndRefreshMarket } from './setup_operations';
+import { sleep } from '../src/classes/utils';
+import {
+  getExpectedTokenBalanceAfterBorrow,
+  getKtokenToTokenSwapper,
+  getTokenToKtokenSwapper,
+} from '../src/leverage/utils';
+import { getAssociatedTokenAddress, getTokenAccountBalance } from '../src/utils/ata';
+import { buildVersionedTransaction, sendAndConfirmVersionedTransaction } from '../src/utils/instruction';
 
 describe('Leverage SDK kTokens swapper tests', function () {
   it('swap_A_to_kAB_A_is_SOL_B_is_SPL', async function () {


### PR DESCRIPTION
This PR contains improvements for multiply/leverage logic, which should speed it up by quite a bit.

Interface Changes:

1. `calculateMultiplyEffects` no longer requires getJupPirce, instead call `collToDebt = await getJupiterPrice(collTokenMint, debtTokenMint);` and pass `collToDebt` as an arg
2. `getDepositWithLeverageIxns`, `getWithdrawWithLeverageIxns` and `getAdjustLeverageIxns` now accept `KaminoObligation` instead of loading it 2/3 times.

### Checklist

- [] if I'm working with the latest farms.so version, I have modified the so with the latest one from master
- [] if I'm working with the latest kamino_lending.so version, I have modified the so with the latest one from master