### PR TITLE
Fix farm refresh in refresh_obligation action

### DIFF
--- a/src/classes/action.ts
+++ b/src/classes/action.ts
@@ -1246,13 +1246,13 @@ export class KaminoAction {
 
     this.addRefreshReserveIxs(allReservesExcludingCurrent, addAllToSetupIxns);
     this.addRefreshFarmsForReserve(
-      allReservesExcludingCurrent.map((r) => this.kaminoMarket.getReserveByAddress(r)!),
+      this.depositReserves.map((r) => this.kaminoMarket.getReserveByAddress(r)!),
       addAllToSetupIxns,
       ReserveFarmKind.Collateral,
       crank
     );
     this.addRefreshFarmsForReserve(
-      allReservesExcludingCurrent.map((r) => this.kaminoMarket.getReserveByAddress(r)!),
+      this.borrowReserves.map((r) => this.kaminoMarket.getReserveByAddress(r)!),
       addAllToSetupIxns,
       ReserveFarmKind.Debt,
       crank


### PR DESCRIPTION
Currently the logic creates refresh ixns for obligation debt reserves collFarms, and also for obligation coll reserves debtFarms, eventhough those should not exist and should not be refreshed

### Checklist

- [] if I'm working with the latest farms.so version, I have modified the so with the latest one from master
- [] if I'm working with the latest kamino_lending.so version, I have modified the so with the latest one from master