### PR TITLE
feat: perf, add the ability to load Kamino Market without reserves

### DIFF
--- a/src/classes/market.ts
+++ b/src/classes/market.ts
@@ -86,9 +86,11 @@ export class KaminoMarket {
     connection: Connection,
     marketAddress: PublicKey,
     programId: PublicKey = PROGRAM_ID,
-    setupLocalTest: boolean = false
+    setupLocalTest: boolean = false,
+    withReserves: boolean = true,
+    lendingMarket?: LendingMarket
   ) {
-    const market = await LendingMarket.fetch(connection, marketAddress, programId);
+    const market = lendingMarket ? lendingMarket : await LendingMarket.fetch(connection, marketAddress, programId);
 
     if (market === null) {
       return null;
@@ -100,7 +102,10 @@ export class KaminoMarket {
       scope = new Scope('localnet', connection);
     }
 
-    const reserves = await getReservesForMarket(marketAddress, connection, programId);
+    const reserves = withReserves
+      ? await getReservesForMarket(marketAddress, connection, programId)
+      : new Map<PublicKey, KaminoReserve>();
+
     return new KaminoMarket(connection, market, marketAddress.toString(), reserves, scope, programId);
   }
 

--- a/src/classes/market.ts
+++ b/src/classes/market.ts
@@ -87,10 +87,9 @@ export class KaminoMarket {
     marketAddress: PublicKey,
     programId: PublicKey = PROGRAM_ID,
     setupLocalTest: boolean = false,
-    withReserves: boolean = true,
-    lendingMarket?: LendingMarket
+    withReserves: boolean = true
   ) {
-    const market = lendingMarket ? lendingMarket : await LendingMarket.fetch(connection, marketAddress, programId);
+    const market = await LendingMarket.fetch(connection, marketAddress, programId);
 
     if (market === null) {
       return null;


### PR DESCRIPTION
### Checklist

- [] if I'm working with the latest farms.so version, I have modified the so with the latest one from master
- [] if I'm working with the latest kamino_lending.so version, I have modified the so with the latest one from master

##

This change will allow the front end to stagger loading of the markets.