### PR TITLE
Fix cumulative borrow rate calculation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kamino-finance/klend-sdk",
-  "version": "2.13.3",
+  "version": "2.13.4",
   "description": "Typescript SDK for interacting with the Kamino Lending (klend) protocol",
   "repository": {
     "type": "git",

--- a/src/classes/reserve.ts
+++ b/src/classes/reserve.ts
@@ -175,11 +175,9 @@ export class KaminoReserve {
    * @returns the stale cumulative borrow rate of the reserve from the last refresh
    */
   getCumulativeBorrowRate(): Decimal {
-    let accSf = new BN(0);
-    for (const value of this.state.liquidity.cumulativeBorrowRateBsf.value.reverse()) {
-      accSf = accSf.add(value);
-      accSf.shrn(64);
-    }
+    // Prevent mutation in place.
+    const rates = [...this.state.liquidity.cumulativeBorrowRateBsf.value].reverse();
+    const accSf = rates.reduce((prev, curr) => prev.iadd(curr).ishrn(64), new BN(0));
     return new Fraction(accSf).toDecimal();
   }
 


### PR DESCRIPTION
This patch fixes possible errors and side effects in the `KaminoReserve.getCumulativeBorrowRate` method.