### PR TITLE
Fix issue where calcs of maxBorrwableAsCole are done on debt reserve

### DIFF
--- a/src/classes/reserve.ts
+++ b/src/classes/reserve.ts
@@ -551,9 +551,9 @@ export class KaminoReserve {
       );
     } else {
       let maxDebtTakenAgainstCollaterals = new Decimal(U64_MAX);
-      const maxDebtAllowedAgainstCollateral = this.getBorrowLimitAgainstCollateralInElevationGroup(eModeGroup - 1).sub(
-        this.getBorrowedAmountAgainstCollateralInElevationGroup(eModeGroup - 1)
-      );
+      const maxDebtAllowedAgainstCollateral = collReserve
+        .getBorrowLimitAgainstCollateralInElevationGroup(eModeGroup - 1)
+        .sub(collReserve.getBorrowedAmountAgainstCollateralInElevationGroup(eModeGroup - 1));
 
       maxDebtTakenAgainstCollaterals = Decimal.max(
         new Decimal(0),

--- a/tests/farms_tests/init_refresh_farm_repay.test.ts
+++ b/tests/farms_tests/init_refresh_farm_repay.test.ts
@@ -290,7 +290,6 @@ describe('init_and_refresh_farm_repay_tests', function () {
     const amountToDeposit = new Decimal(2.5);
     const amountToBorrow = new Decimal(15);
     const amountToRepay = amountToBorrow;
-    const slippagePct = 0.5;
 
     console.log('Setting up market ===');
     const { env, kaminoMarket } = await createMarketWithTwoReservesToppedUp(
@@ -304,9 +303,6 @@ describe('init_and_refresh_farm_repay_tests', function () {
 
     await initializeFarmsForReserve(env, kaminoMarket.getAddress(), collReserve.address, 'Collateral', false, false);
     await initializeFarmsForReserve(env, kaminoMarket.getAddress(), debtReserve.address, 'Debt', false, false);
-
-    const collTokenMint = collReserve.getLiquidityMint();
-    const debtTokenMint = debtReserve.getLiquidityMint();
 
     console.log('Creating user ===');
     const borrower = await newUser(env, kaminoMarket, [

--- a/tests/obligation_types.test.ts
+++ b/tests/obligation_types.test.ts
@@ -44,9 +44,9 @@ describe('Obligation types tests', function () {
     await deposit(env, kaminoMarket, alice, 'MSOL', new Decimal(30), multiply);
     await deposit(env, kaminoMarket, alice, 'MSOL', new Decimal(31), leverage);
 
-    await borrow(env, kaminoMarket, alice, 'USDC', new Decimal(5), vanilla);
-    await borrow(env, kaminoMarket, alice, 'USDC', new Decimal(5), multiply);
-    await borrow(env, kaminoMarket, alice, 'USDC', new Decimal(6), leverage);
+    await borrow(env, kaminoMarket, alice, 'USDC', new Decimal(5), false, vanilla);
+    await borrow(env, kaminoMarket, alice, 'USDC', new Decimal(5), false, multiply);
+    await borrow(env, kaminoMarket, alice, 'USDC', new Decimal(6), false, leverage);
 
     // Bob
     await deposit(env, kaminoMarket, bob, 'MSOL', new Decimal(11), vanilla);
@@ -54,9 +54,9 @@ describe('Obligation types tests', function () {
     await deposit(env, kaminoMarket, bob, 'MSOL', new Decimal(32), multiply);
     await deposit(env, kaminoMarket, bob, 'MSOL', new Decimal(33), leverage);
 
-    await borrow(env, kaminoMarket, bob, 'USDC', new Decimal(5), vanilla);
-    await borrow(env, kaminoMarket, bob, 'USDC', new Decimal(6), multiply);
-    await borrow(env, kaminoMarket, bob, 'USDC', new Decimal(7), leverage);
+    await borrow(env, kaminoMarket, bob, 'USDC', new Decimal(5), false, vanilla);
+    await borrow(env, kaminoMarket, bob, 'USDC', new Decimal(6), false, multiply);
+    await borrow(env, kaminoMarket, bob, 'USDC', new Decimal(7), false, leverage);
 
     await sleep(2000);
 

--- a/tests/setup_utils.ts
+++ b/tests/setup_utils.ts
@@ -1285,7 +1285,7 @@ export async function createMintAndReserve(
       true,
       PublicKey.default,
       0,
-      env.testCase
+      { includeScopeRefresh: false, scopeFeed: env.testCase }
     );
     await sendTransactionsFromAction(env, depositAction, initialDepositor, [initialDepositor]);
   }


### PR DESCRIPTION
### Checklist

- [] if I'm working with the latest farms.so version, I have modified the so with the latest one from master
- [] if I'm working with the latest kamino_lending.so version, I have modified the so with the latest one from master