### PR TITLE
Remove non-effective statement

### DIFF
--- a/src/classes/obligation.ts
+++ b/src/classes/obligation.ts
@@ -1401,7 +1401,6 @@ export class KaminoObligation {
     let accSf = new BN(0);
     for (const value of borrow.cumulativeBorrowRateBsf.value.reverse()) {
       accSf = accSf.add(value);
-      accSf.shrn(64);
     }
     return new Fraction(accSf).toDecimal();
   }


### PR DESCRIPTION
`BN.shrn` method don't modify the value in place, it returns a clone of the original instance which has been modified.

So in this case, the statement have no effect but misleading