### PR TITLE
Remove default lut-update ixs in update-vault-reserve-allocation

### DIFF
--- a/src/manager/client_kamino_manager.ts
+++ b/src/manager/client_kamino_manager.ts
@@ -1421,7 +1421,6 @@ async function main() {
       );
       const txInstructions = [
         instructions.updateReserveAllocationIx,
-        ...instructions.updateLUTIxs,
         ...getPriorityFeeAndCuIxs({
           priorityFeeMultiplier: 2500,
         }),


### PR DESCRIPTION
Remove default lut-update ixs in update-vault-reserve-allocation given updateLUTIxs is correctly added with the shouldUpdateLut check in lines 1429-1431